### PR TITLE
Changed sticky to create a new stylesheet, rather than inserting rules into an existing one

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -1,26 +1,16 @@
 (function ($) {
 
-  // http://davidwalsh.name/ways-css-javascript-interact
-  function addCSSRule (sheet, selector, rules, index) {
-   if (sheet.insertRule) {
-      sheet.insertRule(selector + '{ ' + rules + ' }', index)
-    } else {
-      sheet.addRule(selector, rules, index)
-    }
+  function addCSSRule (selector, rules) {
+    $('head').append('<style type="text/css">' + selector + ' { ' + rules + ' }</style>');
   }
 
   $.fn.sticky = function () {
-
-    var elem = $(this)
-
-    if (elem.css('position') == 'sticky' || elem.css('position') == '-webkit-sticky') return;
-
-    var initialOffset = elem.offset().top,
+    var elem = $(this),
+        initialOffset = elem.offset().top,
         nextVisible = elem.siblings().first(':visible'),
-        stuck = false,
-        styleSheet = document.styleSheets[0]
+        stuck = false
 
-    addCSSRule(styleSheet, '.stuck', 'position: fixed !important; top: 0 !important; z-index: 10')
+    addCSSRule('.stuck', 'position: fixed !important; top: 0 !important; z-index: 10')
 
     $(window).on('scroll', function () {
       var currentPosition = $(window).scrollTop(),


### PR DESCRIPTION
On firefox, using CSSStyleSheet#insertRule raises a security error if the stylesheets are not hosted on the same domain as the page. This is a problem if you use a cdn to host your assets. Instead, I've made the script insert a new stylesheet into the header with the sticky rules. This works for me on all major browsers

I had problems running the tests - the second one fails for me both on master and on my branch (using safari)
