### PR TITLE
Fix margin-top bug in IE8

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -28,14 +28,14 @@
         // The page has scrolled past the top position of the element, so fix it and
         // apply its height as a margin to the next visible element so it doesn't jump
         elem.addClass('stuck')
-        nextVisible.css('margin-top', elem.outerHeight())
+        nextVisible.css('padding-top', elem.outerHeight())
         stuck = true
 
       } else {
 
         // Unstick, because the element can now rest in its original position
         elem.removeClass('stuck')
-        nextVisible.css('margin-top', "")
+        nextVisible.css('padding-top', "")
         stuck = false
       }
     })


### PR DESCRIPTION
Setting margin-top causes weird behaviour on IE8. Using padding instead seems to fix it.

When using margin-top, depending on the markup the nextVisible element will overflow under the element right above it, as if with a negative top-margin.

Might be related to this? http://www.inventpartners.com/ie8_margin_top_bug
