### PR TITLE
Dont rely on padding or margin

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -34,6 +34,8 @@
 
       } else {
 
+        if(!stuck) return;
+
         // Unstick, because the element can now rest in its original position
         elem.removeClass('stuck')
         wedge.css('height', '')


### PR DESCRIPTION
Right now, sticky.js stops the page from jumping (when the sticky menu is changed from static to fixed positioning) by calculating the height of the menu, then adding this height as padding to an element before the menu (this way the height of the page above the sticky menu does not change).

However, this won't work as expected if that preceding element already has padding. For example, if we have this:

``` html
<script type="text/javascript">
  $(function() {
    $("sticky").sticky()
  })
</script>
<div style="padding-top: 100px; height: 10px"></div>
<div id="sticky" style="height: 10px"></div>
```

The current version of sticky will change the top-offset of `#sticky` from 110px (before the menu is stuck) to 20px. This would the page to visually jump.

Using margin or height instead of padding would have the same problem whenever the element that's adjusted already has that property set.

My solution to this problem is to instead of using padding, add a totally new div to the page, with a fixed height.
