### PR TITLE
Changed the height of the wedge to be outer height

### DIFF
--- a/jquery.sticky.js
+++ b/jquery.sticky.js
@@ -45,7 +45,7 @@
         // The page has scrolled past the top position of the element, so fix it and
         // apply its height as a margin to the next visible element so it doesn't jump
         elem.attr('data-stuck', '')
-        wedge.css('height', elem.height() + 'px')
+        wedge.css('height', elem.outerHeight() + 'px')
         stuck = true
 
       } else {


### PR DESCRIPTION
Previously the wedge (put in place to stop the page shifting up when the stuck element becomes fixed) was the inner height of the stuck element. It should probably be the outer height instead (which includes margins). Otherwise there's a judder as the page height changes when the element becomes stuck/unstuck.
